### PR TITLE
Align by width by default

### DIFF
--- a/R/string_operations.r
+++ b/R/string_operations.r
@@ -259,7 +259,7 @@ col_strsplit <- function(x, split, ...) {
 #' @param text The character vector to align.
 #' @param width Width of the field to align in.
 #' @param align Whether to align `"left"`, `"center"` or `"right"`.
-#' @param nchar Passed on to [col_nchar()] and there to [nchar()]
+#' @param type Passed on to [col_nchar()] and there to [nchar()]
 #' @return The aligned character vector.
 #'
 #' @family ANSI string operations

--- a/R/string_operations.r
+++ b/R/string_operations.r
@@ -259,6 +259,7 @@ col_strsplit <- function(x, split, ...) {
 #' @param text The character vector to align.
 #' @param width Width of the field to align in.
 #' @param align Whether to align `"left"`, `"center"` or `"right"`.
+#' @param nchar Passed on to [col_nchar()] and there to [nchar()]
 #' @return The aligned character vector.
 #'
 #' @family ANSI string operations
@@ -269,10 +270,11 @@ col_strsplit <- function(x, split, ...) {
 #' col_align(red("foobar"), 20, "right")
 
 col_align <- function(text, width = getOption("width"),
-                      align = c("left", "center", "right")) {
+                      align = c("left", "center", "right"),
+                      type = "width") {
 
   align <- match.arg(align)
-  nc <- col_nchar(text)
+  nc <- col_nchar(text, type = type)
 
   if (!length(text)) return(text)
 

--- a/man/col_align.Rd
+++ b/man/col_align.Rd
@@ -14,7 +14,7 @@ col_align(text, width = getOption("width"), align = c("left", "center",
 
 \item{align}{Whether to align `"left"`, `"center"` or `"right"`.}
 
-\item{nchar}{Passed on to [col_nchar()] and there to [nchar()]}
+\item{type}{Passed on to [col_nchar()] and there to [nchar()]}
 }
 \value{
 The aligned character vector.

--- a/man/col_align.Rd
+++ b/man/col_align.Rd
@@ -5,7 +5,7 @@
 \title{Align an ANSI colored string}
 \usage{
 col_align(text, width = getOption("width"), align = c("left", "center",
-  "right"))
+  "right"), type = "width")
 }
 \arguments{
 \item{text}{The character vector to align.}
@@ -13,6 +13,8 @@ col_align(text, width = getOption("width"), align = c("left", "center",
 \item{width}{Width of the field to align in.}
 
 \item{align}{Whether to align `"left"`, `"center"` or `"right"`.}
+
+\item{nchar}{Passed on to [col_nchar()] and there to [nchar()]}
 }
 \value{
 The aligned character vector.

--- a/tests/testthat/test-operations.R
+++ b/tests/testthat/test-operations.R
@@ -219,4 +219,17 @@ test_that("col_align", {
   expect_equal(
     col_align(c("foo", "foobar", "", "a"), 6, "right"),
     c("   foo", "foobar", "      ", "     a"))
+
+  # #54: alignment of wide characters
+  expect_equal(
+    col_align(c("foo", "\u6210\u4ea4\u65e5", "", "a"), 6, "left"),
+    c("foo   ", "\u6210\u4ea4\u65e5", "      ", "a     "))
+
+  expect_equal(
+    col_align(c("foo", "\u6210\u4ea4\u65e5", "", "a"), 6, "center"),
+    c("  foo ", "\u6210\u4ea4\u65e5", "      ", "   a  "))
+
+  expect_equal(
+    col_align(c("foo", "\u6210\u4ea4\u65e5", "", "a"), 6, "right"),
+    c("   foo", "\u6210\u4ea4\u65e5", "      ", "     a"))
 })


### PR DESCRIPTION
not by number of characters. Necessary for colformat <- tibble.