### PR TITLE
Avoid warning if INSIDE_EMACS does not contain version.

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -95,10 +95,8 @@ myseq <- function(from, to, by = 1) {
 
 emacs_version <- function() {
   ver <- Sys.getenv("INSIDE_EMACS")
+  ver <- gsub("[^0-9\\.]+", "", ver)  
   if (ver == "") return(NA_integer_)
-
-  ver <- gsub("'", "", ver)
-  ver <- strsplit(ver, ",", fixed = TRUE)[[1]]
   ver <- strsplit(ver, ".", fixed = TRUE)[[1]]
   as.numeric(ver)
 }

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -11,6 +11,9 @@
 
 * `reset` style now restores previous style for text following it (@brodieG,
   #35).
+  
+* Warnings are no longer generated when the INSIDE_EMACS environment variable is
+  set but does not include a version number.
 
 # 1.3.4
 


### PR DESCRIPTION
The INSIDE_EMACS environment variable is not guaranteed to include the version
number. For example, https://github.com/akermu/emacs-libvterm sets it to
"vterm". To avoid warnings in this case we remove all non-numeric characters and
return NA if nothing remains.