### PR TITLE
Enable colors on GitHub Actions

### DIFF
--- a/R/has_color.r
+++ b/R/has_color.r
@@ -63,6 +63,11 @@ has_color <- function() {
   ## Are we in a terminal? No?
   if (!isatty(stdout())) { return(FALSE) }
 
+  ## Are we running on GitHub Actions?
+  if (identical(Sys.getenv("GITHUB_ACTIONS", "false"), "true")) {
+    return(TRUE)
+  }
+
   ## Are we in a windows terminal with color support?
   if (os_type() == "windows") {
     if (Sys.getenv("ConEmuANSI") == "ON") { return(TRUE) }

--- a/R/has_color.r
+++ b/R/has_color.r
@@ -60,13 +60,13 @@ has_color <- function() {
     return(TRUE)
   }
 
-  ## Are we in a terminal? No?
-  if (!isatty(stdout())) { return(FALSE) }
-
   ## Are we running on GitHub Actions?
   if (identical(Sys.getenv("GITHUB_ACTIONS", "false"), "true")) {
     return(TRUE)
   }
+
+  ## Are we in a terminal? No?
+  if (!isatty(stdout())) { return(FALSE) }
 
   ## Are we in a windows terminal with color support?
   if (os_type() == "windows") {


### PR DESCRIPTION
This will work, but I am not sure it is much better than the existing solution of setting the option in setup-r.

I tried a few different ways of not doing this and using a fake tty using script / unbuffer (https://github.com/jimhester/r-actions-test/runs/932366132?check_suite_focus=true#step:10:21) but that doesn't handle `\r` like we would want, so the log while colored looks bad.

Maybe instead of doing this PR we should just set the crayon option just in the workflow step for rcmdcheck?

If you have any other better solutions I would be happy to hear them.