### PR TITLE
Clear color capability cache on load

### DIFF
--- a/R/aaa-rstudio-detect.R
+++ b/R/aaa-rstudio-detect.R
@@ -44,7 +44,7 @@ rstudio <- local({
   detect <- function(clear_cache = FALSE) {
     # Cached?
     if (clear_cache) data <<- list()
-    if (!is.null(data)) return(get_caps(data))
+    if (!is.null(data) && length(data) > 1) return(get_caps(data))
 
     # Otherwise get data
     new <- get_data()

--- a/R/machinery.r
+++ b/R/machinery.r
@@ -312,7 +312,7 @@ sapply(names(builtin_styles), function(style) {
 })
 
 .onLoad <- function(libname, pkgname) {
-  num_colors(forget = TRUE)
+  rstudio$detect(clear_cache = TRUE)
 }
 
 define_style <- function(name, ansi_seq) {


### PR DESCRIPTION
Fixes #104, sort of

I realize you will probably want to implement your own fix, but this *almost* fixes things for me. I thought it was worth getting the ball rolling in any case.

However, since I attach devtools in `.Rprofile`, when crayon is first loaded, RStudio's color capabilities still aren't being detected correctly. But if I comment that out, this fix works. Or if I manually call `crayon:::rstudio$detect(clear_cache = TRUE)` in a session, things are fixed. I believe that has something to do with rstudioapi and the startup process? But that's a real problem, because devtools will often appear in `.Rprofile` (at least for some of us).