### PR TITLE
chore: remove unused mockery from suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ Imports:
     methods,
     utils
 Suggests:
-    mockery,
     rstudioapi,
     testthat,
     withr


### PR DESCRIPTION
Closes: https://github.com/r-lib/crayon/issues/144

Couldn't find any usage of mockery in the package.